### PR TITLE
Local and social spy persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,5 +114,6 @@ run/
 /.gradle/
 /velocity/build/
 /bungeecord/build/
+/bukkit/build/
 /plugin/build/
 /common/build/

--- a/bungeecord/src/main/java/net/william278/huskchat/bungeecord/HuskChatBungee.java
+++ b/bungeecord/src/main/java/net/william278/huskchat/bungeecord/HuskChatBungee.java
@@ -67,7 +67,12 @@ public final class HuskChatBungee extends Plugin implements HuskChat {
 
         // Load saved social spy state
         PlayerCache.setDataFolder(getDataFolder());
-        PlayerCache.loadSpy();
+
+        try {
+            PlayerCache.loadSpy();
+        } catch (IOException e) {
+            getLoggingAdapter().log(Level.SEVERE, "Failed to load spies file");
+        }
 
         // Setup player data getter
         Plugin luckPerms = ProxyServer.getInstance().getPluginManager().getPlugin("LuckPerms");

--- a/bungeecord/src/main/java/net/william278/huskchat/bungeecord/HuskChatBungee.java
+++ b/bungeecord/src/main/java/net/william278/huskchat/bungeecord/HuskChatBungee.java
@@ -24,6 +24,7 @@ import net.william278.huskchat.getter.DefaultDataGetter;
 import net.william278.huskchat.getter.LuckPermsDataGetter;
 import net.william278.huskchat.message.MessageManager;
 import net.william278.huskchat.player.Player;
+import net.william278.huskchat.player.PlayerCache;
 import net.william278.huskchat.util.Logger;
 import org.bstats.bungeecord.Metrics;
 
@@ -63,6 +64,10 @@ public final class HuskChatBungee extends Plugin implements HuskChat {
 
         // Load messages
         reloadMessages();
+
+        // Load saved social spy state
+        PlayerCache.setDataFolder(getDataFolder());
+        PlayerCache.loadSpy();
 
         // Setup player data getter
         Plugin luckPerms = ProxyServer.getInstance().getPluginManager().getPlugin("LuckPerms");

--- a/common/src/main/java/net/william278/huskchat/command/LocalSpyCommand.java
+++ b/common/src/main/java/net/william278/huskchat/command/LocalSpyCommand.java
@@ -54,7 +54,7 @@ public class LocalSpyCommand extends CommandBase {
                     PlayerCache.removeLocalSpy(player);
                     implementor.getMessageManager().sendMessage(player, "local_spy_toggled_off");
                 } catch (IOException e) {
-                    implementor.getLoggingAdapter().log(Level.SEVERE, "Failed to save social spy state to spies file");
+                    implementor.getLoggingAdapter().log(Level.SEVERE, "Failed to save local spy state to spies file");
                 }
             }
         } else {

--- a/common/src/main/java/net/william278/huskchat/command/LocalSpyCommand.java
+++ b/common/src/main/java/net/william278/huskchat/command/LocalSpyCommand.java
@@ -6,6 +6,7 @@ import net.william278.huskchat.player.ConsolePlayer;
 import net.william278.huskchat.player.Player;
 import net.william278.huskchat.player.PlayerCache;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -30,19 +31,31 @@ public class LocalSpyCommand extends CommandBase {
                 PlayerCache.SpyColor color;
                 Optional<PlayerCache.SpyColor> selectedColor = PlayerCache.SpyColor.getColor(args[0]);
                 if (selectedColor.isPresent()) {
-                    color = selectedColor.get();
-                    PlayerCache.setLocalSpy(player, color);
-                    implementor.getMessageManager().sendMessage(player, "local_spy_toggled_on_color",
-                            color.colorCode, color.name().toLowerCase().replaceAll("_", " "));
+                    try {
+                        color = selectedColor.get();
+                        PlayerCache.setLocalSpy(player, color);
+                        implementor.getMessageManager().sendMessage(player, "local_spy_toggled_on_color",
+                                color.colorCode, color.name().toLowerCase().replaceAll("_", " "));
+                    } catch (IOException e) {
+                        implementor.getLoggingAdapter().log(Level.SEVERE, "Failed to save local spy state to spies file");
+                    }
                     return;
                 }
             }
             if (!PlayerCache.isLocalSpying(player)) {
-                PlayerCache.setLocalSpy(player);
-                implementor.getMessageManager().sendMessage(player, "local_spy_toggled_on");
+                try {
+                    PlayerCache.setLocalSpy(player);
+                    implementor.getMessageManager().sendMessage(player, "local_spy_toggled_on");
+                } catch (IOException e) {
+                    implementor.getLoggingAdapter().log(Level.SEVERE, "Failed to save local spy state to spies file");
+                }
             } else {
-                PlayerCache.removeLocalSpy(player);
-                implementor.getMessageManager().sendMessage(player, "local_spy_toggled_off");
+                try {
+                    PlayerCache.removeLocalSpy(player);
+                    implementor.getMessageManager().sendMessage(player, "local_spy_toggled_off");
+                } catch (IOException e) {
+                    implementor.getLoggingAdapter().log(Level.SEVERE, "Failed to save social spy state to spies file");
+                }
             }
         } else {
             implementor.getMessageManager().sendMessage(player, "error_no_permission");

--- a/common/src/main/java/net/william278/huskchat/command/SocialSpyCommand.java
+++ b/common/src/main/java/net/william278/huskchat/command/SocialSpyCommand.java
@@ -6,6 +6,7 @@ import net.william278.huskchat.player.ConsolePlayer;
 import net.william278.huskchat.player.Player;
 import net.william278.huskchat.player.PlayerCache;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -30,19 +31,31 @@ public class SocialSpyCommand extends CommandBase {
                 PlayerCache.SpyColor color;
                 Optional<PlayerCache.SpyColor> selectedColor = PlayerCache.SpyColor.getColor(args[0]);
                 if (selectedColor.isPresent()) {
-                    color = selectedColor.get();
-                    PlayerCache.setSocialSpy(player, color);
-                    implementor.getMessageManager().sendMessage(player, "social_spy_toggled_on_color",
-                            color.colorCode, color.name().toLowerCase().replaceAll("_", " "));
+                    try {
+                        color = selectedColor.get();
+                        PlayerCache.setSocialSpy(player, color);
+                        implementor.getMessageManager().sendMessage(player, "social_spy_toggled_on_color",
+                                color.colorCode, color.name().toLowerCase().replaceAll("_", " "));
+                    } catch (IOException e) {
+                        implementor.getLoggingAdapter().log(Level.SEVERE, "Failed to save social spy state to spies file");
+                    }
                     return;
                 }
             }
             if (!PlayerCache.isSocialSpying(player)) {
-                PlayerCache.setSocialSpy(player);
-                implementor.getMessageManager().sendMessage(player, "social_spy_toggled_on");
+                try {
+                    PlayerCache.setSocialSpy(player);
+                    implementor.getMessageManager().sendMessage(player, "social_spy_toggled_on");
+                } catch (IOException e) {
+                    implementor.getLoggingAdapter().log(Level.SEVERE, "Failed to save social spy state to spies file");
+                }
             } else {
-                PlayerCache.removeSocialSpy(player);
-                implementor.getMessageManager().sendMessage(player, "social_spy_toggled_off");
+                try {
+                    PlayerCache.removeSocialSpy(player);
+                    implementor.getMessageManager().sendMessage(player, "social_spy_toggled_off");
+                } catch (IOException e) {
+                    implementor.getLoggingAdapter().log(Level.SEVERE, "Failed to save social spy state to spies file");
+                }
             }
         } else {
             implementor.getMessageManager().sendMessage(player, "error_no_permission");

--- a/common/src/main/java/net/william278/huskchat/player/PlayerCache.java
+++ b/common/src/main/java/net/william278/huskchat/player/PlayerCache.java
@@ -79,17 +79,17 @@ public class PlayerCache {
         return socialSpies.containsKey(player.getUuid());
     }
 
-    public static void setSocialSpy(Player player) {
+    public static void setSocialSpy(Player player) throws IOException {
         socialSpies.put(player.getUuid(), SpyColor.DEFAULT_SPY_COLOR);
         addSpy("social", player.getUuid(), SpyColor.DEFAULT_SPY_COLOR);
     }
 
-    public static void setSocialSpy(Player player, SpyColor spyColor) {
+    public static void setSocialSpy(Player player, SpyColor spyColor) throws IOException {
         socialSpies.put(player.getUuid(), spyColor);
         addSpy("social", player.getUuid(), spyColor);
     }
 
-    public static void removeSocialSpy(Player player) {
+    public static void removeSocialSpy(Player player) throws IOException {
         socialSpies.remove(player.getUuid());
         removeSpy("social", player.getUuid());
     }
@@ -118,17 +118,17 @@ public class PlayerCache {
         return localSpies.containsKey(player.getUuid());
     }
 
-    public static void setLocalSpy(Player player) {
+    public static void setLocalSpy(Player player) throws IOException {
         localSpies.put(player.getUuid(), SpyColor.DEFAULT_SPY_COLOR);
         addSpy("local", player.getUuid(), SpyColor.DEFAULT_SPY_COLOR);
     }
 
-    public static void setLocalSpy(Player player, SpyColor spyColor) {
+    public static void setLocalSpy(Player player, SpyColor spyColor) throws IOException {
         localSpies.put(player.getUuid(), spyColor);
         addSpy("local", player.getUuid(), spyColor);
     }
 
-    public static void removeLocalSpy(Player player) {
+    public static void removeLocalSpy(Player player) throws IOException {
         localSpies.remove(player.getUuid());
         removeSpy("local", player.getUuid());
     }
@@ -150,80 +150,65 @@ public class PlayerCache {
     }
 
     // Load local and social spy data into maps
-    public static void loadSpy() {
-        try {
-            YamlDocument spies = YamlDocument.create(new File(dataFolder, "spies.yml"));
+    public static void loadSpy() throws IOException {
+        YamlDocument spies = YamlDocument.create(new File(dataFolder, "spies.yml"));
 
-            if (spies.contains("local")) {
-                Section local = spies.getSection("local");
+        if (spies.contains("local")) {
+            Section local = spies.getSection("local");
 
-                for (Object name : local.getKeys()) {
-                    localSpies.put(UUID.fromString(name.toString()),
-                            SpyColor.valueOf(local.getSection(name.toString()).getString("color")));
-                }
+            for (Object name : local.getKeys()) {
+                localSpies.put(UUID.fromString(name.toString()),
+                        SpyColor.valueOf(local.getSection(name.toString()).getString("color")));
             }
+        }
 
-            if (spies.contains("social")) {
-                Section social = spies.getSection("social");
+        if (spies.contains("social")) {
+            Section social = spies.getSection("social");
 
-                for (Object name : social.getKeys()) {
-                    socialSpies.put(UUID.fromString(name.toString()),
-                            SpyColor.valueOf(social.getSection(name.toString()).getString("color")));
-                }
+            for (Object name : social.getKeys()) {
+                socialSpies.put(UUID.fromString(name.toString()),
+                        SpyColor.valueOf(social.getSection(name.toString()).getString("color")));
             }
-        } catch(IOException e) {
-            // TODO: Use logger
-            e.printStackTrace();
         }
     }
 
     // Adds spy state to data file
-    public static void addSpy(String type, UUID uuid, SpyColor spyColor) {
-        try {
-            if (!type.equals("local") && !type.equals("social")) return;
+    public static void addSpy(String type, UUID uuid, SpyColor spyColor) throws IOException {
+        if (!type.equals("local") && !type.equals("social")) return;
 
-            YamlDocument spies = YamlDocument.create(new File(dataFolder, "spies.yml"));
+        YamlDocument spies = YamlDocument.create(new File(dataFolder, "spies.yml"));
 
-            if (!spies.contains(type)) {
-                spies.createSection(type);
-            }
-
-            if (!spies.getSection(type).contains(uuid.toString())) {
-                spies.getSection(type).createSection(uuid.toString());
-            }
-
-            spies.getSection(type)
-                    .getSection(uuid.toString())
-                    .set("color", spyColor.toString());
-            spies.save();
-        } catch (IOException e) {
-            // TODO: Use logger
-            e.printStackTrace();
+        if (!spies.contains(type)) {
+            spies.createSection(type);
         }
+
+        if (!spies.getSection(type).contains(uuid.toString())) {
+            spies.getSection(type).createSection(uuid.toString());
+        }
+
+        spies.getSection(type)
+                .getSection(uuid.toString())
+                .set("color", spyColor.toString());
+        spies.save();
     }
 
     // Removes spy state from data file
-    public static void removeSpy(String type, UUID uuid) {
-        try {
-            if (!type.equals("local") && !type.equals("social")) return;
+    public static void removeSpy(String type, UUID uuid) throws IOException {
+        if (!type.equals("local") && !type.equals("social")) return;
 
-            YamlDocument spies = YamlDocument.create(new File(dataFolder, "spies.yml"));
+        YamlDocument spies = YamlDocument.create(new File(dataFolder, "spies.yml"));
 
-            if (!spies.contains(type)) return;
-            if (!spies.getSection(type).contains(uuid.toString())) return;
+        if (!spies.contains(type)) return;
+        if (!spies.getSection(type).contains(uuid.toString())) return;
 
-            spies.getSection(type)
-                    .remove(uuid.toString());
+        spies.getSection(type)
+                .remove(uuid.toString());
 
-            if (spies.getSection(type).getKeys().size() == 0) {
-                spies.remove(type);
-            }
-
-            spies.save();
-        } catch (IOException e) {
-            // TODO: Use logger
-            e.printStackTrace();
+        if (spies.getSection(type).getKeys().size() == 0) {
+            spies.remove(type);
         }
+
+        spies.save();
     }
 
 

--- a/common/src/main/java/net/william278/huskchat/player/PlayerCache.java
+++ b/common/src/main/java/net/william278/huskchat/player/PlayerCache.java
@@ -189,7 +189,7 @@ public class PlayerCache {
             }
 
             if (!spies.getSection(type).contains(uuid.toString())) {
-                spies.createSection(type).createSection(uuid.toString());
+                spies.getSection(type).createSection(uuid.toString());
             }
 
             spies.getSection(type)

--- a/velocity/src/main/java/net/william278/huskchat/velocity/HuskChatVelocity.java
+++ b/velocity/src/main/java/net/william278/huskchat/velocity/HuskChatVelocity.java
@@ -22,6 +22,7 @@ import net.william278.huskchat.getter.DefaultDataGetter;
 import net.william278.huskchat.getter.LuckPermsDataGetter;
 import net.william278.huskchat.message.MessageManager;
 import net.william278.huskchat.player.Player;
+import net.william278.huskchat.player.PlayerCache;
 import net.william278.huskchat.util.Logger;
 import net.william278.huskchat.velocity.command.VelocityCommand;
 import net.william278.huskchat.velocity.config.VelocityMessageManager;
@@ -93,6 +94,10 @@ public class HuskChatVelocity implements HuskChat {
 
         // Load messages
         reloadMessages();
+
+        // Load saved social spy state
+        PlayerCache.setDataFolder(getDataFolder());
+        PlayerCache.loadSpy();
 
         // Setup player data getter
         Optional<PluginContainer> luckPerms = getProxyServer().getPluginManager().getPlugin("luckperms");

--- a/velocity/src/main/java/net/william278/huskchat/velocity/HuskChatVelocity.java
+++ b/velocity/src/main/java/net/william278/huskchat/velocity/HuskChatVelocity.java
@@ -97,7 +97,12 @@ public class HuskChatVelocity implements HuskChat {
 
         // Load saved social spy state
         PlayerCache.setDataFolder(getDataFolder());
-        PlayerCache.loadSpy();
+
+        try {
+            PlayerCache.loadSpy();
+        } catch (IOException e) {
+            getLoggingAdapter().log(Level.SEVERE, "Failed to load spies file");
+        }
 
         // Setup player data getter
         Optional<PluginContainer> luckPerms = getProxyServer().getPluginManager().getPlugin("luckperms");


### PR DESCRIPTION
This pull request adds local and social spy persistence, fixing #25.

While this might not be the best code (I haven't written Java in a while), I feel it implements the feature in a satisfactory way. It's been tested to work with Velocity, but should work with BungeeCord too.

The data is stored in a YAML file in the plugin's data directory, in the following format:
```yaml
social:
  bcb70186-ea67-4346-85c5-33edf9576526:
    color: DARK_GRAY
local:
  bcb70186-ea67-4346-85c5-33edf9576526:
    color: DARK_GRAY
```