### PR TITLE
Escape player name to prevent text formatting

### DIFF
--- a/common/src/main/java/net/william278/huskchat/util/PlaceholderReplacer.java
+++ b/common/src/main/java/net/william278/huskchat/util/PlaceholderReplacer.java
@@ -13,8 +13,8 @@ public class PlaceholderReplacer {
         final HashMap<String, String> placeholders = new HashMap<>();
 
         // Player related placeholders
-        placeholders.put("%name%", implementingPlugin.getDataGetter().getPlayerName(player));
-        placeholders.put("%fullname%", implementingPlugin.getDataGetter().getPlayerFullName(player));
+        placeholders.put("%name%", escape(implementingPlugin.getDataGetter().getPlayerName(player)));
+        placeholders.put("%fullname%", escape(implementingPlugin.getDataGetter().getPlayerFullName(player)));
         placeholders.put("%prefix%", implementingPlugin.getDataGetter().getPlayerPrefix(player).isPresent() ? implementingPlugin.getDataGetter().getPlayerPrefix(player).get() : "");
         placeholders.put("%suffix%", implementingPlugin.getDataGetter().getPlayerSuffix(player).isPresent() ? implementingPlugin.getDataGetter().getPlayerSuffix(player).get() : "");
         placeholders.put("%ping%", Integer.toString(player.getPing()));
@@ -39,6 +39,14 @@ public class PlaceholderReplacer {
         }
 
         return message;
+    }
+
+    public static String escape(String string) {
+        // Just escaping __ should suffice as the only special character
+        // allowed in Minecraft usernames is the underscore.
+        // By placing the escape character in the middle, the MineDown
+        // parser no longer sees this as a formatting code.
+        return string.replace("__", "_\\_");
     }
 
 }


### PR DESCRIPTION
This pull request escapes player names to prevent text formatting being applied to them, fixing #21.

As I didn't have access to an account that triggers this bug, temporary changes were made to the code during testing. Due to this, there may be some bugs but I doubt it.

Before:
![javaw_YUQCE6TrAB](https://user-images.githubusercontent.com/30316407/162647781-c97e1b91-789d-478d-a721-da16ea8cf4ac.png)

After:
![javaw_CQYU39IzXQ](https://user-images.githubusercontent.com/30316407/162647777-5db67540-b9a3-4b74-a400-6664f074fc23.png)

Only the `%name%` and `%fullname%` placeholders are escaped.