### PR TITLE
Make HuskChat command executable from console

### DIFF
--- a/bungeecord/src/main/java/net/william278/huskchat/bungeecord/util/BungeeLogger.java
+++ b/bungeecord/src/main/java/net/william278/huskchat/bungeecord/util/BungeeLogger.java
@@ -1,9 +1,13 @@
 package net.william278.huskchat.bungeecord.util;
 
+import de.themoep.minedown.MineDown;
+import de.themoep.minedown.MineDownParser;
 import net.william278.huskchat.bungeecord.HuskChatBungee;
 import net.william278.huskchat.util.Logger;
 
 import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class BungeeLogger implements Logger {
 
@@ -22,26 +26,61 @@ public class BungeeLogger implements Logger {
 
     @Override
     public void log(Level level, String s, Exception e) {
-        plugin.getLogger().log(level, s, e);
+        plugin.getLogger().log(level, stripMineDown(s), e);
     }
 
     @Override
     public void log(Level level, String s) {
-        plugin.getLogger().log(level, s);
+        plugin.getLogger().log(level, stripMineDown(s));
     }
 
     @Override
     public void info(String s) {
-        plugin.getLogger().info(s);
+        plugin.getLogger().info(stripMineDown(s));
     }
 
     @Override
     public void severe(String s) {
-        plugin.getLogger().severe(s);
+        plugin.getLogger().severe(stripMineDown(s));
     }
 
     @Override
     public void config(String s) {
-        plugin.getLogger().config(s);
+        plugin.getLogger().config(stripMineDown(s));
+    }
+
+    private String stripMineDown(String message) {
+        String out = "";
+        String[] lines = message.split("\n");
+
+        for (int i = 0; i < lines.length; i++) {
+            out += handleMineDownLinks(lines[i]);
+        }
+
+        // This would work perfectly on its own, if there weren't links
+        return MineDown.stringify(new MineDown(out)
+                .filter(MineDownParser.Option.ADVANCED_FORMATTING)
+                .filter(MineDownParser.Option.SIMPLE_FORMATTING)
+                .filter(MineDownParser.Option.LEGACY_COLORS)
+                .toComponent());
+    }
+
+    private String handleMineDownLinks(String string) {
+        String out = "";
+        // this regex extracts the text and url, only supports one link per line
+        String regex = "[^\\[\\]\\(\\) ]*\\[([^\\(\\)]+)\\]\\([^\\(\\)]+open_url=(\\S+).*\\)";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher m = pattern.matcher(string);
+
+        if (m.find()) {
+            // match 0 is the whole match, 1 is the text, 2 is the url
+            out += string.replace(m.group(0), "");
+            out += m.group(1) + ": " + m.group(2);
+        } else {
+            out += string;
+        }
+
+        out += "\n";
+        return out;
     }
 }

--- a/common/src/main/java/net/william278/huskchat/command/HuskChatCommand.java
+++ b/common/src/main/java/net/william278/huskchat/command/HuskChatCommand.java
@@ -23,7 +23,7 @@ public class HuskChatCommand extends CommandBase {
         this.pluginInformation = "[HuskChat](#00fb9a bold) [| " + implementor.getMetaPlatform() + " Version " + implementor.getMetaVersion() + "](#00fb9a)\n" +
                 "[" + implementor.getMetaDescription() + "](gray)\n" +
                 "[• Author:](white) [William278](gray show_text=&7Click to visit website open_url=https://william278.net)\n" +
-                "[• Contributors:](white) [TrueWinter](gray show_text=&Code)\n" +
+                "[• Contributors:](white) [TrueWinter](gray show_text=&7Code)\n" +
                 "[• Translators:](white) [xF3d3](gray show_text=&7Italian, it-it), [MalzSmith](gray show_text=&7Hungarian, hu-hu)\n" +
                 "[• Help Wiki:](white) [[Link]](#00fb9a show_text=&7Click to open link open_url=https://github.com/WiIIiam278/HuskChat/wiki/)\n" +
                 "[• Report Issues:](white) [[Link]](#00fb9a show_text=&7Click to open link open_url=https://github.com/WiIIiam278/HuskChat/issues)\n" +
@@ -32,23 +32,41 @@ public class HuskChatCommand extends CommandBase {
 
     @Override
     public void onExecute(Player player, String[] args) {
-        if (player instanceof ConsolePlayer) {
-            implementor.getLoggingAdapter().log(Level.INFO, implementor.getMessageManager().getRawMessage("error_in_game_only"));
-            return;
-        }
-        if (player.hasPermission(permission)) {
+        boolean isConsole = player instanceof ConsolePlayer;
+        if (player.hasPermission(permission) || isConsole) {
             if (args.length == 1) {
                 switch (args[0].toLowerCase(Locale.ROOT)) {
-                    case "about", "info" -> sendAboutInformation(player);
+                    case "about", "info" -> {
+                        if (!isConsole) {
+                            sendAboutInformation(player);
+                        } else {
+                            implementor.getLoggingAdapter().log(Level.INFO, pluginInformation);
+                        }
+                    }
                     case "reload" -> {
                         implementor.reloadSettings();
                         implementor.reloadMessages();
-                        implementor.getMessageManager().sendCustomMessage(player, "[HuskChat](#00fb9a bold) &#00fb9a&| Reloaded config & message files.");
+
+                        if (!isConsole) {
+                            implementor.getMessageManager().sendCustomMessage(player, "[HuskChat](#00fb9a bold) &#00fb9a&| Reloaded config & message files.");
+                        } else {
+                            implementor.getLoggingAdapter().log(Level.INFO, "[HuskChat](#00fb9a bold) &#00fb9a&| Reloaded config & message files.");
+                        }
                     }
-                    default -> implementor.getMessageManager().sendMessage(player, "error_invalid_syntax", "/huskchat <about/reload>");
+                    default -> {
+                        if (!isConsole) {
+                            implementor.getMessageManager().sendMessage(player, "error_invalid_syntax", "/huskchat <about/reload>");
+                        } else {
+                            implementor.getLoggingAdapter().log(Level.INFO, implementor.getMessageManager().getRawMessage("error_invalid_syntax", "/huskchat <about/reload>"));
+                        }
+                    }
                 }
             } else {
-                sendAboutInformation(player);
+                if (!isConsole) {
+                    sendAboutInformation(player);
+                } else {
+                    implementor.getLoggingAdapter().log(Level.INFO, pluginInformation);
+                }
             }
         } else {
             implementor.getMessageManager().sendMessage(player, "error_no_permission");

--- a/common/src/main/java/net/william278/huskchat/command/HuskChatCommand.java
+++ b/common/src/main/java/net/william278/huskchat/command/HuskChatCommand.java
@@ -23,7 +23,7 @@ public class HuskChatCommand extends CommandBase {
         this.pluginInformation = "[HuskChat](#00fb9a bold) [| " + implementor.getMetaPlatform() + " Version " + implementor.getMetaVersion() + "](#00fb9a)\n" +
                 "[" + implementor.getMetaDescription() + "](gray)\n" +
                 "[• Author:](white) [William278](gray show_text=&7Click to visit website open_url=https://william278.net)\n" +
-                "[• Contributors:](white) [TrueWinter](gray show_text=&7Code)\n" +
+                "[• Contributors:](white) [TrueWinter](gray show_text=&7Code), [Ironboundred](gray show_text=&7Code)\n" +
                 "[• Translators:](white) [xF3d3](gray show_text=&7Italian, it-it), [MalzSmith](gray show_text=&7Hungarian, hu-hu)\n" +
                 "[• Help Wiki:](white) [[Link]](#00fb9a show_text=&7Click to open link open_url=https://github.com/WiIIiam278/HuskChat/wiki/)\n" +
                 "[• Report Issues:](white) [[Link]](#00fb9a show_text=&7Click to open link open_url=https://github.com/WiIIiam278/HuskChat/issues)\n" +

--- a/velocity/src/main/java/net/william278/huskchat/velocity/util/VelocityLogger.java
+++ b/velocity/src/main/java/net/william278/huskchat/velocity/util/VelocityLogger.java
@@ -1,8 +1,12 @@
 package net.william278.huskchat.velocity.util;
 
+import de.themoep.minedown.adventure.MineDown;
+import de.themoep.minedown.adventure.MineDownParser;
 import net.william278.huskchat.util.Logger;
 
 import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class VelocityLogger implements Logger {
 
@@ -50,10 +54,45 @@ public class VelocityLogger implements Logger {
     // Logs the message using SLF4J
     private void logMessage(Level level, String message) {
         switch (level.intValue()) {
-            case 1000 -> parent.error(message); // Severe
-            case 900 -> parent.warn(message); // Warning
-            case 70 -> parent.warn("[Config] " + message);
-            default -> parent.info(message);
+            case 1000 -> parent.error(stripMineDown(message)); // Severe
+            case 900 -> parent.warn(stripMineDown(message)); // Warning
+            case 70 -> parent.warn("[Config] " + stripMineDown(message));
+            default -> parent.info(stripMineDown(message));
         }
+    }
+
+    private String stripMineDown(String message) {
+        String out = "";
+        String[] lines = message.split("\n");
+
+        for (int i = 0; i < lines.length; i++) {
+            out += handleMineDownLinks(lines[i]);
+        }
+
+        // This would work perfectly on its own, if there weren't links
+        return MineDown.stringify(new MineDown(out)
+            .filter(MineDownParser.Option.ADVANCED_FORMATTING)
+            .filter(MineDownParser.Option.SIMPLE_FORMATTING)
+            .filter(MineDownParser.Option.LEGACY_COLORS)
+            .toComponent());
+    }
+
+    private String handleMineDownLinks(String string) {
+        String out = "";
+        // this regex extracts the text and url, only supports one link per line
+        String regex = "[^\\[\\]\\(\\) ]*\\[([^\\(\\)]+)\\]\\([^\\(\\)]+open_url=(\\S+).*\\)";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher m = pattern.matcher(string);
+
+        if (m.find()) {
+            // match 0 is the whole match, 1 is the text, 2 is the url
+            out += string.replace(m.group(0), "");
+            out += m.group(1) + ": " + m.group(2);
+        } else {
+            out += string;
+        }
+
+        out += "\n";
+        return out;
     }
 }


### PR DESCRIPTION
This pull request makes `/huskchat`, as well as its sub-commands (like the reload command), executable from console as requested in #27.

To prevent MineDown text from being shown in console, links are extracted by regex before the whole string is passed to MineDown to filter out formatting codes, leaving just the text behind. The regex solution isn't great, but it works.

![ubuntu_CjE9qG6CIv](https://user-images.githubusercontent.com/30316407/162794752-1727d928-8694-4b14-ba63-210a9039c94f.png)

