### PR TITLE
Added permission check before sending social/local spy messages

### DIFF
--- a/common/src/main/java/net/william278/huskchat/message/ChatMessage.java
+++ b/common/src/main/java/net/william278/huskchat/message/ChatMessage.java
@@ -116,7 +116,7 @@ public class ChatMessage {
                                     try {
                                         PlayerCache.removeLocalSpy(sender);
                                     } catch(IOException e) {
-                                        implementor.getLoggingAdapter().log(Level.SEVERE, "Failed to remove local spy after failed permission check");
+                                        implementor.getLoggingAdapter().log(Level.SEVERE, "Failed to remove local spy after failed permission check", e);
                                     }
                                     continue;
                                 }

--- a/common/src/main/java/net/william278/huskchat/message/ChatMessage.java
+++ b/common/src/main/java/net/william278/huskchat/message/ChatMessage.java
@@ -111,6 +111,9 @@ public class ChatMessage {
                                 if (spy.getUuid().equals(sender.getUuid())) {
                                     continue;
                                 }
+                                if (!sender.hasPermission("huskchat.command.localspy")) {
+                                    continue;
+                                }
                                 final PlayerCache.SpyColor color = spies.get(spy);
                                 implementor.getMessageManager().sendFormattedLocalSpyMessage(spy, color, sender, channel, message);
                             }

--- a/common/src/main/java/net/william278/huskchat/message/ChatMessage.java
+++ b/common/src/main/java/net/william278/huskchat/message/ChatMessage.java
@@ -8,6 +8,7 @@ import net.william278.huskchat.filter.replacer.ReplacerFilter;
 import net.william278.huskchat.player.Player;
 import net.william278.huskchat.player.PlayerCache;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.logging.Level;
@@ -112,6 +113,11 @@ public class ChatMessage {
                                     continue;
                                 }
                                 if (!sender.hasPermission("huskchat.command.localspy")) {
+                                    try {
+                                        PlayerCache.removeLocalSpy(sender);
+                                    } catch(IOException e) {
+                                        implementor.getLoggingAdapter().log(Level.SEVERE, "Failed to remove local spy after failed permission check");
+                                    }
                                     continue;
                                 }
                                 final PlayerCache.SpyColor color = spies.get(spy);

--- a/common/src/main/java/net/william278/huskchat/message/PrivateMessage.java
+++ b/common/src/main/java/net/william278/huskchat/message/PrivateMessage.java
@@ -48,6 +48,9 @@ public record PrivateMessage(Player sender, String targetUsername,
                     if (spy.getUuid().equals(sender.getUuid()) || spy.getUuid().equals(target.getUuid())) {
                         continue;
                     }
+                    if (!sender.hasPermission("huskchat.command.socialspy")) {
+                        continue;
+                    }
                     final PlayerCache.SpyColor color = spies.get(spy);
                     implementor.getMessageManager().sendFormattedSocialSpyMessage(spy, color, sender, target, message);
                 }

--- a/common/src/main/java/net/william278/huskchat/message/PrivateMessage.java
+++ b/common/src/main/java/net/william278/huskchat/message/PrivateMessage.java
@@ -53,7 +53,7 @@ public record PrivateMessage(Player sender, String targetUsername,
                         try {
                             PlayerCache.removeSocialSpy(sender);
                         } catch(IOException e) {
-                            implementor.getLoggingAdapter().log(Level.SEVERE, "Failed to remove social spy after failed permission check");
+                            implementor.getLoggingAdapter().log(Level.SEVERE, "Failed to remove social spy after failed permission check", e);
                         }
                         continue;
                     }

--- a/common/src/main/java/net/william278/huskchat/message/PrivateMessage.java
+++ b/common/src/main/java/net/william278/huskchat/message/PrivateMessage.java
@@ -5,6 +5,7 @@ import net.william278.huskchat.config.Settings;
 import net.william278.huskchat.player.Player;
 import net.william278.huskchat.player.PlayerCache;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.logging.Level;
 
@@ -49,6 +50,11 @@ public record PrivateMessage(Player sender, String targetUsername,
                         continue;
                     }
                     if (!sender.hasPermission("huskchat.command.socialspy")) {
+                        try {
+                            PlayerCache.removeSocialSpy(sender);
+                        } catch(IOException e) {
+                            implementor.getLoggingAdapter().log(Level.SEVERE, "Failed to remove social spy after failed permission check");
+                        }
                         continue;
                     }
                     final PlayerCache.SpyColor color = spies.get(spy);


### PR DESCRIPTION
This pull request adds a permission check before sending social/local spy messages, fixing #37.

Before (temporarily removed a previous bug fix as I didn't have a third account): 
![javaw_EbmrD6bJIk](https://user-images.githubusercontent.com/30316407/163030130-d53a2eab-2ba0-4326-bb92-de8ba5103301.png)

After:
![javaw_9oFKTCt523](https://user-images.githubusercontent.com/30316407/163030248-d35d2e10-e66a-4381-a9cf-dd8f2acaf5f9.png)

