### PR TITLE
Added socialspy bypass permissions

### DIFF
--- a/common/src/main/java/net/william278/huskchat/message/PrivateMessage.java
+++ b/common/src/main/java/net/william278/huskchat/message/PrivateMessage.java
@@ -43,14 +43,17 @@ public record PrivateMessage(Player sender, String targetUsername,
 
             // Show message to social spies
             if (Settings.doSocialSpyCommand) {
-                final HashMap<Player, PlayerCache.SpyColor> spies = PlayerCache.getSocialSpyMessageReceivers(target.getUuid(), implementor);
-                for (Player spy : spies.keySet()) {
-                    if (spy.getUuid().equals(sender.getUuid()) || spy.getUuid().equals(target.getUuid())) {
-                        continue;
+                if (!sender.hasPermission("huskchat.command.socialspy.bypass") && !target.hasPermission("huskchat.command.socialspy.bypass")){
+                    final HashMap<Player, PlayerCache.SpyColor> spies = PlayerCache.getSocialSpyMessageReceivers(target.getUuid(), implementor);
+                    for (Player spy : spies.keySet()) {
+                        if (spy.getUuid().equals(sender.getUuid()) || spy.getUuid().equals(target.getUuid())) {
+                            continue;
+                        }
+                        final PlayerCache.SpyColor color = spies.get(spy);
+                        implementor.getMessageManager().sendFormattedSocialSpyMessage(spy, color, sender, target, message);
                     }
-                    final PlayerCache.SpyColor color = spies.get(spy);
-                    implementor.getMessageManager().sendFormattedSocialSpyMessage(spy, color, sender, target, message);
                 }
+
             }
 
             // Log to console if enabled


### PR DESCRIPTION
players with the permission huskchat.command.socialspy.bypass would not have their private messages spied on.