### PR TITLE
Make some commands executable from console

### DIFF
--- a/bungeecord/src/main/java/net/william278/huskchat/bungeecord/config/BungeeMessageManager.java
+++ b/bungeecord/src/main/java/net/william278/huskchat/bungeecord/config/BungeeMessageManager.java
@@ -2,7 +2,6 @@ package net.william278.huskchat.bungeecord.config;
 
 import de.themoep.minedown.MineDown;
 import de.themoep.minedown.MineDownParser;
-import de.themoep.minedown.MineDownStringifier;
 import dev.dejvokep.boostedyaml.YamlDocument;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.william278.huskchat.bungeecord.HuskChatBungee;

--- a/bungeecord/src/main/java/net/william278/huskchat/bungeecord/config/BungeeMessageManager.java
+++ b/bungeecord/src/main/java/net/william278/huskchat/bungeecord/config/BungeeMessageManager.java
@@ -2,6 +2,7 @@ package net.william278.huskchat.bungeecord.config;
 
 import de.themoep.minedown.MineDown;
 import de.themoep.minedown.MineDownParser;
+import de.themoep.minedown.MineDownStringifier;
 import dev.dejvokep.boostedyaml.YamlDocument;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.william278.huskchat.bungeecord.HuskChatBungee;
@@ -9,6 +10,7 @@ import net.william278.huskchat.bungeecord.player.BungeePlayer;
 import net.william278.huskchat.channel.Channel;
 import net.william278.huskchat.config.Settings;
 import net.william278.huskchat.message.MessageManager;
+import net.william278.huskchat.player.ConsolePlayer;
 import net.william278.huskchat.player.Player;
 import net.william278.huskchat.player.PlayerCache;
 import net.william278.huskchat.util.PlaceholderReplacer;
@@ -46,6 +48,11 @@ public class BungeeMessageManager extends MessageManager {
             replacementIndexer = replacementIndexer + 1;
         }
 
+        if (player instanceof ConsolePlayer) {
+            sendMineDownToConsole(message);
+            return;
+        }
+
         // Convert to baseComponents[] via MineDown formatting and send
         String finalMessage = message;
         BungeePlayer.adaptBungee(player).ifPresent(bungeePlayer -> bungeePlayer.sendMessage(new MineDown(finalMessage).replace().toComponent()));
@@ -63,12 +70,22 @@ public class BungeeMessageManager extends MessageManager {
             return;
         }
 
+        if (player instanceof ConsolePlayer) {
+            sendMineDownToConsole(message);
+            return;
+        }
+
         // Convert to baseComponents[] via MineDown formatting and send
         BungeePlayer.adaptBungee(player).ifPresent(bungeePlayer -> bungeePlayer.sendMessage(new MineDown(message).replace().toComponent()));
     }
 
     @Override
     public void sendCustomMessage(Player player, String message) {
+        if (player instanceof ConsolePlayer) {
+            sendMineDownToConsole(message);
+            return;
+        }
+
         BungeePlayer.adaptBungee(player).ifPresent(bungeePlayer -> bungeePlayer.sendMessage(new MineDown(message).replace().toComponent()));
     }
 
@@ -143,5 +160,9 @@ public class BungeeMessageManager extends MessageManager {
         componentBuilder.append(new MineDown(Settings.broadcastMessageFormat).toComponent());
         componentBuilder.append(new MineDown(message).disable(MineDownParser.Option.ADVANCED_FORMATTING).toComponent());
         BungeePlayer.adaptBungee(player).ifPresent(bungeePlayer -> bungeePlayer.sendMessage(componentBuilder.create()));
+    }
+
+    private void sendMineDownToConsole(String minedown) {
+        plugin.getProxy().getConsole().sendMessage(new MineDown(extractMineDownLinks(minedown)).toComponent());
     }
 }

--- a/common/src/main/java/net/william278/huskchat/command/HuskChatCommand.java
+++ b/common/src/main/java/net/william278/huskchat/command/HuskChatCommand.java
@@ -23,7 +23,7 @@ public class HuskChatCommand extends CommandBase {
         this.pluginInformation = "[HuskChat](#00fb9a bold) [| " + implementor.getMetaPlatform() + " Version " + implementor.getMetaVersion() + "](#00fb9a)\n" +
                 "[" + implementor.getMetaDescription() + "](gray)\n" +
                 "[• Author:](white) [William278](gray show_text=&7Click to visit website open_url=https://william278.net)\n" +
-                "[• Contributors:](white) [TrueWinter](gray show_text=&Code), [Ironboundred](gray show_text=&Code)\n" +
+                "[• Contributors:](white) [TrueWinter](gray show_text=&7Code), [Ironboundred](gray show_text=&7Code)\n" +
                 "[• Translators:](white) [xF3d3](gray show_text=&7Italian, it-it), [MalzSmith](gray show_text=&7Hungarian, hu-hu)\n" +
                 "[• Help Wiki:](white) [[Link]](#00fb9a show_text=&7Click to open link open_url=https://github.com/WiIIiam278/HuskChat/wiki/)\n" +
                 "[• Report Issues:](white) [[Link]](#00fb9a show_text=&7Click to open link open_url=https://github.com/WiIIiam278/HuskChat/issues)\n" +
@@ -32,10 +32,6 @@ public class HuskChatCommand extends CommandBase {
 
     @Override
     public void onExecute(Player player, String[] args) {
-        if (player instanceof ConsolePlayer) {
-            implementor.getLoggingAdapter().log(Level.INFO, implementor.getMessageManager().getRawMessage("error_in_game_only"));
-            return;
-        }
         if (player.hasPermission(permission)) {
             if (args.length == 1) {
                 switch (args[0].toLowerCase(Locale.ROOT)) {

--- a/common/src/main/java/net/william278/huskchat/command/ShortcutCommand.java
+++ b/common/src/main/java/net/william278/huskchat/command/ShortcutCommand.java
@@ -24,12 +24,14 @@ public class ShortcutCommand extends CommandBase {
 
     @Override
     public void onExecute(Player player, String[] args) {
-        if (player instanceof ConsolePlayer) {
-            implementor.getLoggingAdapter().log(Level.INFO, implementor.getMessageManager().getRawMessage("error_in_game_only"));
-            return;
-        }
         if (player.hasPermission(permission)) {
             if (args.length == 0) {
+                // Console can't chat in the same way as players can, it can only use commands.
+                // So no need to allow it to switch channels.
+                if (player instanceof ConsolePlayer) {
+                    implementor.getLoggingAdapter().log(Level.INFO, implementor.getMessageManager().getRawMessage("error_in_game_only"));
+                    return;
+                }
                 PlayerCache.switchPlayerChannel(player, channelId, implementor.getMessageManager());
             } else {
                 StringJoiner message = new StringJoiner(" ");

--- a/common/src/main/java/net/william278/huskchat/command/ShortcutCommand.java
+++ b/common/src/main/java/net/william278/huskchat/command/ShortcutCommand.java
@@ -29,7 +29,7 @@ public class ShortcutCommand extends CommandBase {
                 // Console can't chat in the same way as players can, it can only use commands.
                 // So no need to allow it to switch channels.
                 if (player instanceof ConsolePlayer) {
-                    implementor.getLoggingAdapter().log(Level.INFO, implementor.getMessageManager().getRawMessage("error_in_game_only"));
+                    implementor.getLoggingAdapter().log(Level.INFO, implementor.getMessageManager().getRawMessage("error_console_switch_channels"));
                     return;
                 }
                 PlayerCache.switchPlayerChannel(player, channelId, implementor.getMessageManager());

--- a/common/src/main/java/net/william278/huskchat/message/ChatMessage.java
+++ b/common/src/main/java/net/william278/huskchat/message/ChatMessage.java
@@ -5,6 +5,7 @@ import net.william278.huskchat.channel.Channel;
 import net.william278.huskchat.config.Settings;
 import net.william278.huskchat.filter.ChatFilter;
 import net.william278.huskchat.filter.replacer.ReplacerFilter;
+import net.william278.huskchat.player.ConsolePlayer;
 import net.william278.huskchat.player.Player;
 import net.william278.huskchat.player.PlayerCache;
 
@@ -55,6 +56,14 @@ public class ChatMessage {
 
                 // Determine the players who will receive the message;
                 Channel.BroadcastScope broadcastScope = channel.broadcastScope;
+
+                // There's no point in allowing console to send to local chat as it's not actually in any servers and
+                // therefore the message won't get sent to anyone
+                if (sender instanceof ConsolePlayer && (broadcastScope == Channel.BroadcastScope.LOCAL ||
+                        broadcastScope == Channel.BroadcastScope.LOCAL_PASSTHROUGH)) {
+                    implementor.getLoggingAdapter().log(Level.INFO, implementor.getMessageManager().getRawMessage("error_in_game_only"));
+                    return;
+                }
 
                 // If the message is to be filtered, then perform filter checks (unless they have the bypass permission)
                 if (channel.filter && !sender.hasPermission("huskchat.bypass_filters")) {

--- a/common/src/main/java/net/william278/huskchat/message/ChatMessage.java
+++ b/common/src/main/java/net/william278/huskchat/message/ChatMessage.java
@@ -61,7 +61,7 @@ public class ChatMessage {
                 // therefore the message won't get sent to anyone
                 if (sender instanceof ConsolePlayer && (broadcastScope == Channel.BroadcastScope.LOCAL ||
                         broadcastScope == Channel.BroadcastScope.LOCAL_PASSTHROUGH)) {
-                    implementor.getLoggingAdapter().log(Level.INFO, implementor.getMessageManager().getRawMessage("error_in_game_only"));
+                    implementor.getLoggingAdapter().log(Level.INFO, implementor.getMessageManager().getRawMessage("error_console_local_scope"));
                     return;
                 }
 

--- a/common/src/main/java/net/william278/huskchat/message/MessageManager.java
+++ b/common/src/main/java/net/william278/huskchat/message/MessageManager.java
@@ -7,6 +7,8 @@ import net.william278.huskchat.player.PlayerCache;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public abstract class MessageManager {
 
@@ -38,6 +40,33 @@ public abstract class MessageManager {
             replacementIndexer = replacementIndexer + 1;
         }
         return message;
+    }
+
+    public String extractMineDownLinks(String string) {
+        String[] in = string.split("\n");
+        String out = "";
+        // This regex extracts the text and url, only supports one link per line.
+        // Definitely not a great solution, but it's better than any alternatives I can think of.
+        String regex = "[^\\[\\]\\(\\) ]*\\[([^\\(\\)]+)\\]\\([^\\(\\)]+open_url=(\\S+).*\\)";
+
+        for (int i = 0; i < in.length; i++) {
+            Pattern pattern = Pattern.compile(regex);
+            Matcher m = pattern.matcher(in[i]);
+
+            if (m.find()) {
+                // match 0 is the whole match, 1 is the text, 2 is the url
+                out += in[i].replace(m.group(0), "");
+                out += m.group(2);
+            } else {
+                out += in[i];
+            }
+
+            if (i + 1 != in.length) {
+                out += "\n";
+            }
+        }
+
+        return out;
     }
 
     // Send a message to the correct channel

--- a/common/src/main/resources/languages/en-gb.yml
+++ b/common/src/main/resources/languages/en-gb.yml
@@ -34,3 +34,5 @@ error_chat_filter_spam: '[Please wait! You are sending messages too quickly.](#f
 error_chat_filter_ascii: '[You cannot use special characters in chat.](#ff7e5e)'
 error_chat_filter_repeat: '[You''ve already sent that message recently!](#ff7e5e)'
 error_in_game_only: 'Error: That command can only be used in-game.'
+error_console_local_scope: 'Error: Sending messages from console to channels with a local scope is unsupported.'
+error_console_switch_channels: 'Error: You cannot switch to another channel from console. Please use the shortcut command instead.'

--- a/common/src/main/resources/languages/hu-hu.yml
+++ b/common/src/main/resources/languages/hu-hu.yml
@@ -34,3 +34,5 @@ error_chat_filter_spam: '[Kérlek várj! Túl gyorsan küldesz üzenetet.](#ff7e
 error_chat_filter_ascii: '[Nem használhatsz speciális karaktereket a chat-en!](#ff7e5e)'
 error_chat_filter_repeat: '[Nemrég már elküldted ezt az üzentet!](#ff7e5e)'
 error_in_game_only: 'Hiba: Ez a parancs csak játékon belül használható!'
+error_console_local_scope: 'Hiba: Az üzenetek konzolról helyi hatókörrel rendelkező csatornákra történő küldése nem támogatott.'
+error_console_switch_channels: 'Hiba: Nem lehet másik csatornára váltani a konzolról. Használja helyette a parancsikont.'

--- a/common/src/main/resources/languages/it-it.yml
+++ b/common/src/main/resources/languages/it-it.yml
@@ -34,3 +34,5 @@ error_chat_filter_spam: '[Per favore aspetta! Stai mandando messaggi troppo velo
 error_chat_filter_ascii: '[Non puoi usare caratteri speciali in chat.](#ff7e5e)'
 error_chat_filter_repeat: '[Hai già mandato questo messaggio recentemente!](#ff7e5e)'
 error_in_game_only: 'Error: That command can only be used in-game.'
+error_console_local_scope: 'Error: l''invio di messaggi dalla console ai canali con ambito locale non è supportato.'
+error_console_switch_channels: 'Error: non puoi passare a un altro canale dalla console. Utilizzare invece il comando di scelta rapida.'

--- a/velocity/src/main/java/net/william278/huskchat/velocity/config/VelocityMessageManager.java
+++ b/velocity/src/main/java/net/william278/huskchat/velocity/config/VelocityMessageManager.java
@@ -2,12 +2,9 @@ package net.william278.huskchat.velocity.config;
 
 import de.themoep.minedown.adventure.MineDown;
 import de.themoep.minedown.adventure.MineDownParser;
-import de.themoep.minedown.adventure.MineDownStringifier;
 import dev.dejvokep.boostedyaml.YamlDocument;
-import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.william278.huskchat.HuskChat;
 import net.william278.huskchat.channel.Channel;
 import net.william278.huskchat.config.Settings;

--- a/velocity/src/main/java/net/william278/huskchat/velocity/config/VelocityMessageManager.java
+++ b/velocity/src/main/java/net/william278/huskchat/velocity/config/VelocityMessageManager.java
@@ -2,13 +2,17 @@ package net.william278.huskchat.velocity.config;
 
 import de.themoep.minedown.adventure.MineDown;
 import de.themoep.minedown.adventure.MineDownParser;
+import de.themoep.minedown.adventure.MineDownStringifier;
 import dev.dejvokep.boostedyaml.YamlDocument;
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.william278.huskchat.HuskChat;
 import net.william278.huskchat.channel.Channel;
 import net.william278.huskchat.config.Settings;
 import net.william278.huskchat.message.MessageManager;
+import net.william278.huskchat.player.ConsolePlayer;
 import net.william278.huskchat.player.Player;
 import net.william278.huskchat.player.PlayerCache;
 import net.william278.huskchat.util.PlaceholderReplacer;
@@ -49,6 +53,11 @@ public class VelocityMessageManager extends MessageManager {
             replacementIndexer = replacementIndexer + 1;
         }
 
+        if (player instanceof ConsolePlayer) {
+            sendMineDownToConsole(message);
+            return;
+        }
+
         // Convert to baseComponents[] via MineDown formatting and send
         String finalMessage = message;
         VelocityPlayer.adaptVelocity(player).ifPresent(user -> user.sendMessage(new MineDown(finalMessage).toComponent()));
@@ -66,12 +75,21 @@ public class VelocityMessageManager extends MessageManager {
             return;
         }
 
+        if (player instanceof ConsolePlayer) {
+            sendMineDownToConsole(message);
+            return;
+        }
+
         // Convert to baseComponents[] via MineDown formatting and send
         VelocityPlayer.adaptVelocity(player).ifPresent(user -> user.sendMessage(new MineDown(message).toComponent()));
     }
 
     @Override
     public void sendCustomMessage(Player player, String message) {
+        if (player instanceof ConsolePlayer) {
+            sendMineDownToConsole(message);
+            return;
+        }
         VelocityPlayer.adaptVelocity(player).ifPresent(user -> user.sendMessage(new MineDown(message).toComponent()));
     }
 
@@ -144,5 +162,9 @@ public class VelocityMessageManager extends MessageManager {
         componentBuilder.append(new MineDown(Settings.broadcastMessageFormat).toComponent());
         componentBuilder.append(new MineDown(message).disable(MineDownParser.Option.ADVANCED_FORMATTING).toComponent());
         VelocityPlayer.adaptVelocity(player).ifPresent(user -> user.sendMessage(componentBuilder.build()));
+    }
+
+    private void sendMineDownToConsole(String minedown) {
+        plugin.getProxyServer().getConsoleCommandSource().sendMessage(new MineDown(extractMineDownLinks(minedown)).toComponent());
     }
 }


### PR DESCRIPTION
This pull request makes /huskchat, as well as its sub-commands (like the reload command), executable from console as requested in #27.

To ensure links are shown in console, a regex solution (similar to the one from #34) is used. It isn't great, but I can't think of any better solutions.

It also allows console to send messages in channels with the `GLOBAL` scope. The `LOCAL` scope isn't supported as the server isn't actually in any of the servers, and therefore the message won't get sent to anyone.

![ubuntu_ZcVgcPNvSW](https://user-images.githubusercontent.com/30316407/164565752-c2558bc2-2064-4267-9a71-5516da8b712e.png)
![javaw_J3Bgz9R1ZD](https://user-images.githubusercontent.com/30316407/164565759-1389c1ca-3f81-4651-8d42-a08174f17a2a.png)

