### PR TITLE
Properly escape name formatting for socialspy

### DIFF
--- a/bungeecord/src/main/java/net/william278/huskchat/bungeecord/message/BungeeMessageManager.java
+++ b/bungeecord/src/main/java/net/william278/huskchat/bungeecord/message/BungeeMessageManager.java
@@ -182,7 +182,6 @@ public class BungeeMessageManager extends MessageManager {
                                                     Settings.socialSpyFormat.replaceAll("%sender_", "%"),
                                                     plugin)
                                             .replaceAll("%receiver_", "%"), plugin)
-                            .replaceAll("%receiever_name%", receiver.getName())
                             .replaceAll("%spy_color%", spyColor.colorCode)).toComponent())
                     .append(message);
         } else {
@@ -196,7 +195,6 @@ public class BungeeMessageManager extends MessageManager {
                             .replaceAll("%group_amount%", Integer.toString(receivers.size() - 1))
                             .replaceAll("%group_members%", getGroupMemberList(receivers, "\n"))
                             .replaceAll("%group_members_comma_separated%", getGroupMemberList(receivers, ","))
-                            .replaceAll("%receiever_name%", firstReceiver.getName())
                             .replaceAll("%spy_color%", spyColor.colorCode)).toComponent())
                     .append(message);
         }

--- a/bungeecord/src/main/java/net/william278/huskchat/bungeecord/message/BungeeMessageManager.java
+++ b/bungeecord/src/main/java/net/william278/huskchat/bungeecord/message/BungeeMessageManager.java
@@ -112,10 +112,10 @@ public class BungeeMessageManager extends MessageManager {
         } else {
             componentBuilder.append(new MineDown(
                     PlaceholderReplacer.replace(messageRecipients.get(0), Settings.groupOutboundMessageFormat, plugin)
-                            .replaceAll("%group_amount_subscript%", convertToUnicodeSubScript(messageRecipients.size() - 1))
-                            .replaceAll("%group_amount%", Integer.toString(messageRecipients.size() - 1))
-                            .replaceAll("%group_members_comma_separated%", getGroupMemberList(messageRecipients, ","))
-                            .replaceAll("%group_members%", getGroupMemberList(messageRecipients, "\n")))
+                            .replace("%group_amount_subscript%", convertToUnicodeSubScript(messageRecipients.size() - 1))
+                            .replace("%group_amount%", Integer.toString(messageRecipients.size() - 1))
+                            .replace("%group_members_comma_separated%", getGroupMemberList(messageRecipients, ","))
+                            .replace("%group_members%", MineDown.escape(getGroupMemberList(messageRecipients, "\n"))))
                     .toComponent());
         }
         if (messageSender.hasPermission("huskchat.formatted_chat")) {
@@ -140,10 +140,10 @@ public class BungeeMessageManager extends MessageManager {
         } else {
             componentBuilder.append(new MineDown(
                     PlaceholderReplacer.replace(messageSender, Settings.groupInboundMessageFormat, plugin)
-                            .replaceAll("%group_amount_subscript%", convertToUnicodeSubScript(messageRecipients.size() - 1))
-                            .replaceAll("%group_amount%", Integer.toString(messageRecipients.size() - 1))
-                            .replaceAll("%group_members_comma_separated%", getGroupMemberList(messageRecipients, ","))
-                            .replaceAll("%group_members%", getGroupMemberList(messageRecipients, "\n")))
+                            .replace("%group_amount_subscript%", convertToUnicodeSubScript(messageRecipients.size() - 1))
+                            .replace("%group_amount%", Integer.toString(messageRecipients.size() - 1))
+                            .replace("%group_members_comma_separated%", getGroupMemberList(messageRecipients, ","))
+                            .replace("%group_members%", MineDown.escape(getGroupMemberList(messageRecipients, "\n"))))
                     .toComponent());
         }
         if (messageSender.hasPermission("huskchat.formatted_chat")) {
@@ -166,7 +166,7 @@ public class BungeeMessageManager extends MessageManager {
                                              Channel channel, String message) {
         final ComponentBuilder componentBuilder = new ComponentBuilder()
                 .append(new MineDown(PlaceholderReplacer.replace(sender, Settings.localSpyFormat, plugin)
-                        .replaceAll("%spy_color%", spyColor.colorCode)).toComponent())
+                        .replace("%spy_color%", spyColor.colorCode)).toComponent())
                 .append(message);
         BungeePlayer.adaptBungee(spy).ifPresent(bungeePlayer -> bungeePlayer.sendMessage(componentBuilder.create()));
     }
@@ -179,23 +179,23 @@ public class BungeeMessageManager extends MessageManager {
             final Player receiver = receivers.get(0);
             componentBuilder.append(new MineDown(PlaceholderReplacer.replace(receiver,
                                     PlaceholderReplacer.replace(sender,
-                                                    Settings.socialSpyFormat.replaceAll("%sender_", "%"),
+                                                    Settings.socialSpyFormat.replace("%sender_", "%"),
                                                     plugin)
-                                            .replaceAll("%receiver_", "%"), plugin)
-                            .replaceAll("%spy_color%", spyColor.colorCode)).toComponent())
+                                            .replace("%receiver_", "%"), plugin)
+                            .replace("%spy_color%", spyColor.colorCode)).toComponent())
                     .append(message);
         } else {
             final Player firstReceiver = receivers.get(0);
             componentBuilder.append(new MineDown(PlaceholderReplacer.replace(firstReceiver,
                                     PlaceholderReplacer.replace(sender,
-                                                    Settings.socialSpyGroupFormat.replaceAll("%sender_", "%"),
+                                                    Settings.socialSpyGroupFormat.replace("%sender_", "%"),
                                                     plugin)
-                                            .replaceAll("%receiver_", "%"), plugin)
-                            .replaceAll("%group_amount_subscript%", convertToUnicodeSubScript(receivers.size() - 1))
-                            .replaceAll("%group_amount%", Integer.toString(receivers.size() - 1))
-                            .replaceAll("%group_members%", getGroupMemberList(receivers, "\n"))
-                            .replaceAll("%group_members_comma_separated%", getGroupMemberList(receivers, ","))
-                            .replaceAll("%spy_color%", spyColor.colorCode)).toComponent())
+                                            .replace("%receiver_", "%"), plugin)
+                            .replace("%group_amount_subscript%", convertToUnicodeSubScript(receivers.size() - 1))
+                            .replace("%group_amount%", Integer.toString(receivers.size() - 1))
+                            .replace("%group_members%", MineDown.escape(getGroupMemberList(receivers, "\n")))
+                            .replace("%group_members_comma_separated%", getGroupMemberList(receivers, ","))
+                            .replace("%spy_color%", spyColor.colorCode)).toComponent())
                     .append(message);
         }
         BungeePlayer.adaptBungee(spy).ifPresent(bungeePlayer -> bungeePlayer.sendMessage(componentBuilder.create()));

--- a/common/src/main/java/net/william278/huskchat/config/Settings.java
+++ b/common/src/main/java/net/william278/huskchat/config/Settings.java
@@ -100,7 +100,7 @@ public class Settings {
 
         // Social spy
         doSocialSpyCommand = configFile.getBoolean("social_spy.enabled", true);
-        socialSpyFormat = configFile.getString("social_spy.format", "&e[Spy] &7%sender% &8→ &7%receiever%:%spy_color% ");
+        socialSpyFormat = configFile.getString("social_spy.format", "&e[Spy] &7%sender% &8→ &7%receiver%:%spy_color% ");
         socialSpyGroupFormat = configFile.getString("social_spy.group_format", "&e[Spy] &7%sender_name% &8→ &7%receiver_name%[₍₊%group_amount_subscript%₎](gray show_text=&7%group_members%):%spy_color% ");
         socialSpyCommandAliases = (configFile.contains("social_spy.socialspy_aliases")) ? getCommandsFromList(configFile.getStringList("social_spy.socialspy_aliases")) : Collections.singletonList("socialspy");
 

--- a/common/src/main/java/net/william278/huskchat/message/MessageManager.java
+++ b/common/src/main/java/net/william278/huskchat/message/MessageManager.java
@@ -95,8 +95,7 @@ public abstract class MessageManager {
     public final String getGroupMemberList(ArrayList<Player> players, String delimiter) {
         final StringJoiner memberList = new StringJoiner(delimiter);
         for (Player player : players) {
-            // Escaping weirdness: just a normal escape (\\) doesn't work here
-            memberList.add(PlaceholderReplacer.doubleEscape(player.getName()));
+            memberList.add(player.getName());
         }
         return memberList.toString();
     }

--- a/common/src/main/java/net/william278/huskchat/message/MessageManager.java
+++ b/common/src/main/java/net/william278/huskchat/message/MessageManager.java
@@ -4,6 +4,7 @@ import dev.dejvokep.boostedyaml.YamlDocument;
 import net.william278.huskchat.channel.Channel;
 import net.william278.huskchat.player.Player;
 import net.william278.huskchat.player.PlayerCache;
+import net.william278.huskchat.util.PlaceholderReplacer;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -94,7 +95,8 @@ public abstract class MessageManager {
     public final String getGroupMemberList(ArrayList<Player> players, String delimiter) {
         final StringJoiner memberList = new StringJoiner(delimiter);
         for (Player player : players) {
-            memberList.add(player.getName());
+            // Escaping weirdness: just a normal escape (\\) doesn't work here
+            memberList.add(PlaceholderReplacer.doubleEscape(player.getName()));
         }
         return memberList.toString();
     }

--- a/common/src/main/java/net/william278/huskchat/util/PlaceholderReplacer.java
+++ b/common/src/main/java/net/william278/huskchat/util/PlaceholderReplacer.java
@@ -49,4 +49,8 @@ public class PlaceholderReplacer {
         return string.replace("__", "_\\_");
     }
 
+    public static String doubleEscape(String string) {
+        // Because sometimes escaping once just isn't enough
+        return string.replace("__", "_\\\\_");
+    }
 }

--- a/common/src/main/java/net/william278/huskchat/util/PlaceholderReplacer.java
+++ b/common/src/main/java/net/william278/huskchat/util/PlaceholderReplacer.java
@@ -48,9 +48,4 @@ public class PlaceholderReplacer {
         // parser no longer sees this as a formatting code.
         return string.replace("__", "_\\_");
     }
-
-    public static String doubleEscape(String string) {
-        // Because sometimes escaping once just isn't enough
-        return string.replace("__", "_\\\\_");
-    }
 }

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -90,7 +90,7 @@ message_command:
 # Options for the /socialspy command
 social_spy:
   enabled: true
-  format: '&e[Spy] &7%sender_name% &8→ &7%receiever_name%:%spy_color% '
+  format: '&e[Spy] &7%sender_name% &8→ &7%receiver_name%:%spy_color% '
   group_format: '&e[Spy] &7%sender_name% &8→ &7%receiver_name% [₍₊%group_amount_subscript%₎](gray show_text=&7%group_members% suggest_command=/msg %group_members_comma_separated% ):%spy_color% '
   socialspy_aliases:
     - /socialspy

--- a/velocity/src/main/java/net/william278/huskchat/velocity/message/VelocityMessageManager.java
+++ b/velocity/src/main/java/net/william278/huskchat/velocity/message/VelocityMessageManager.java
@@ -114,10 +114,10 @@ public class VelocityMessageManager extends MessageManager {
         } else {
             componentBuilder.append(new MineDown(
                     PlaceholderReplacer.replace(messageRecipients.get(0), Settings.groupOutboundMessageFormat, plugin)
-                            .replaceAll("%group_amount_subscript%", convertToUnicodeSubScript(messageRecipients.size() - 1))
-                            .replaceAll("%group_amount%", Integer.toString(messageRecipients.size() - 1))
-                            .replaceAll("%group_members_comma_separated%", getGroupMemberList(messageRecipients, ","))
-                            .replaceAll("%group_members%", getGroupMemberList(messageRecipients, "\n")))
+                            .replace("%group_amount_subscript%", convertToUnicodeSubScript(messageRecipients.size() - 1))
+                            .replace("%group_amount%", Integer.toString(messageRecipients.size() - 1))
+                            .replace("%group_members_comma_separated%", getGroupMemberList(messageRecipients, ","))
+                            .replace("%group_members%", MineDown.escape(getGroupMemberList(messageRecipients, "\n"))))
                     .toComponent());
         }
         if (messageSender.hasPermission("huskchat.formatted_chat")) {
@@ -142,10 +142,10 @@ public class VelocityMessageManager extends MessageManager {
         } else {
             componentBuilder.append(new MineDown(
                     PlaceholderReplacer.replace(messageSender, Settings.groupInboundMessageFormat, plugin)
-                            .replaceAll("%group_amount_subscript%", convertToUnicodeSubScript(messageRecipients.size() - 1))
-                            .replaceAll("%group_amount%", Integer.toString(messageRecipients.size() - 1))
-                            .replaceAll("%group_members_comma_separated%", getGroupMemberList(messageRecipients, ","))
-                            .replaceAll("%group_members%", getGroupMemberList(messageRecipients, "\n")))
+                            .replace("%group_amount_subscript%", convertToUnicodeSubScript(messageRecipients.size() - 1))
+                            .replace("%group_amount%", Integer.toString(messageRecipients.size() - 1))
+                            .replace("%group_members_comma_separated%", getGroupMemberList(messageRecipients, ","))
+                            .replace("%group_members%", MineDown.escape(getGroupMemberList(messageRecipients, "\n"))))
                     .toComponent());
         }
         if (messageSender.hasPermission("huskchat.formatted_chat")) {
@@ -167,7 +167,7 @@ public class VelocityMessageManager extends MessageManager {
                                              Channel channel, String message) {
         final TextComponent.Builder componentBuilder = Component.text()
                 .append(new MineDown(PlaceholderReplacer.replace(sender, Settings.localSpyFormat, plugin)
-                        .replaceAll("%spy_color%", spyColor.colorCode) + MineDown.escape(message)).toComponent());
+                        .replace("%spy_color%", spyColor.colorCode) + MineDown.escape(message)).toComponent());
         VelocityPlayer.adaptVelocity(spy).ifPresent(user -> user.sendMessage(componentBuilder.build()));
     }
 
@@ -179,22 +179,24 @@ public class VelocityMessageManager extends MessageManager {
             final Player receiver = receivers.get(0);
             componentBuilder.append(new MineDown(PlaceholderReplacer.replace(receiver,
                             PlaceholderReplacer.replace(sender,
-                                            Settings.socialSpyFormat.replaceAll("%sender_", "%"),
+                                            Settings.socialSpyFormat.replace("%sender_", "%"),
                                             plugin)
-                                    .replaceAll("%receiver_", "%"), plugin)
-                    .replaceAll("%spy_color%", spyColor.colorCode) + MineDown.escape(message)).toComponent());
+                                    .replace("%receiver_", "%"), plugin)
+                    .replace("%spy_color%", spyColor.colorCode) + MineDown.escape(message)).toComponent());
         } else {
             final Player firstReceiver = receivers.get(0);
-            componentBuilder.append(new MineDown(PlaceholderReplacer.replace(firstReceiver,
+            String md = PlaceholderReplacer.replace(firstReceiver,
                             PlaceholderReplacer.replace(sender,
-                                            Settings.socialSpyGroupFormat.replaceAll("%sender_", "%"),
+                                            Settings.socialSpyGroupFormat.replace("%sender_", "%"),
                                             plugin)
-                                    .replaceAll("%receiver_", "%"), plugin)
-                    .replaceAll("%group_amount_subscript%", convertToUnicodeSubScript(receivers.size() - 1))
-                    .replaceAll("%group_amount%", Integer.toString(receivers.size() - 1))
-                    .replaceAll("%group_members_comma_separated%", getGroupMemberList(receivers, ","))
-                    .replaceAll("%group_members%", getGroupMemberList(receivers, "\n"))
-                    .replaceAll("%spy_color%", spyColor.colorCode) + MineDown.escape(message)).toComponent());
+                                    .replace("%receiver_", "%"), plugin)
+                    .replace("%group_amount_subscript%", convertToUnicodeSubScript(receivers.size() - 1))
+                    .replace("%group_amount%", Integer.toString(receivers.size() - 1))
+                    .replace("%group_members_comma_separated%", getGroupMemberList(receivers, ","))
+                    .replace("%group_members%", MineDown.escape(getGroupMemberList(receivers, "\n")))
+                    .replace("%spy_color%", spyColor.colorCode) + MineDown.escape(message);
+
+            componentBuilder.append(new MineDown(md).toComponent());
         }
         VelocityPlayer.adaptVelocity(spy).ifPresent(bungeePlayer -> bungeePlayer.sendMessage(componentBuilder));
     }

--- a/velocity/src/main/java/net/william278/huskchat/velocity/message/VelocityMessageManager.java
+++ b/velocity/src/main/java/net/william278/huskchat/velocity/message/VelocityMessageManager.java
@@ -182,7 +182,6 @@ public class VelocityMessageManager extends MessageManager {
                                             Settings.socialSpyFormat.replaceAll("%sender_", "%"),
                                             plugin)
                                     .replaceAll("%receiver_", "%"), plugin)
-                    .replaceAll("%receiever_name%", receiver.getName())
                     .replaceAll("%spy_color%", spyColor.colorCode) + MineDown.escape(message)).toComponent());
         } else {
             final Player firstReceiver = receivers.get(0);
@@ -195,7 +194,6 @@ public class VelocityMessageManager extends MessageManager {
                     .replaceAll("%group_amount%", Integer.toString(receivers.size() - 1))
                     .replaceAll("%group_members_comma_separated%", getGroupMemberList(receivers, ","))
                     .replaceAll("%group_members%", getGroupMemberList(receivers, "\n"))
-                    .replaceAll("%receiever_name%", firstReceiver.getName())
                     .replaceAll("%spy_color%", spyColor.colorCode) + MineDown.escape(message)).toComponent());
         }
         VelocityPlayer.adaptVelocity(spy).ifPresent(bungeePlayer -> bungeePlayer.sendMessage(componentBuilder));


### PR DESCRIPTION
This pull request fixes #51.

In doing so, it also removes an unnecessarily misspelled placeholder variable that already had code to properly handle the correctly spelt one. This unfortunately means that users of the plugin will need to update their config upon updating the plugin.

If needed, I can modify this pull request to continue supporting the other placeholder variable.