### PR TITLE
Add permission to silently join/leave servers

### DIFF
--- a/common/src/main/java/net/william278/huskchat/config/Locales.java
+++ b/common/src/main/java/net/william278/huskchat/config/Locales.java
@@ -41,6 +41,8 @@ public class Locales {
 
     private final HuskChat plugin;
     private final Map<String, String> locales = new LinkedHashMap<>();
+    private static final String SILENT_JOIN_PERMISSION = "huskchat.silent_join";
+    private static final String SILENT_QUIT_PERMISSION = "huskchat.silent_quit";
 
     public Locales(@NotNull HuskChat plugin) {
         this.plugin = plugin;
@@ -208,7 +210,9 @@ public class Locales {
     }
 
     public void sendJoinMessage(@NotNull Player player) {
-        if(player.hasPermission("huskchat.silent_join")) return;
+        if (player.hasPermission(SILENT_JOIN_PERMISSION)) {
+            return;
+        }
         plugin.replacePlaceholders(player,
                         plugin.getDataGetter().getTextFromNode(player, "huskchat.join_message")
                                 .orElse(plugin.getSettings().getJoinMessageFormat()))
@@ -216,7 +220,9 @@ public class Locales {
     }
 
     public void sendQuitMessage(@NotNull Player player) {
-        if(player.hasPermission("huskchat.silent_leave")) return;
+        if (player.hasPermission(SILENT_QUIT_PERMISSION)) {
+            return;
+        }
         plugin.replacePlaceholders(player,
                         plugin.getDataGetter().getTextFromNode(player, "huskchat.quit_message")
                                 .orElse(plugin.getSettings().getQuitMessageFormat()))

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -205,10 +205,12 @@ join_and_quit_messages:
   join:
     enabled: false
     # Use the huskchat.join_message.[text] permission to override this per-group if needed
+    # Use the huskchat.silent_join permission for a player to join without sending a message
     format: '&e%name% joined the network'
   quit:
     enabled: false
     # Use the huskchat.quit_message.[text] permission to override this per-group if needed
+    # Use the huskchat.silent_quit permission for a player to quit without sending a message
     format: '&e%name% left the network'
   broadcast_scope: GLOBAL # Note that on Velocity/Bungee, PASSTHROUGH modes won't cancel local join/quit messages
 


### PR DESCRIPTION
If ``join_and_quit_messages.join.enabled`` is set to true, the server won't send a join message (the ones handled by huskchat) to any players with the permission ``huskchat.silent_join``

vice versa for the leave messages.